### PR TITLE
Devel shrink

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.
+*.cpp text
 *.c text
 *.h text
 

--- a/src/jsonconfig.cpp
+++ b/src/jsonconfig.cpp
@@ -24,6 +24,7 @@ SOFTWARE. */
 
 Config config;
 static const char *filename = FILENAME;
+const char *apiKey = API_KEY;
 
 bool deleteConfigFile()
 {

--- a/src/jsonconfig.h
+++ b/src/jsonconfig.h
@@ -178,4 +178,6 @@ bool deserializeConfig(Stream &);
 void convertConfigtoImperial();
 void convertConfigtoMetric();
 
+extern const char *apiKey;
+
 #endif // _JSONCONFIG_H

--- a/src/kegscreen.cpp
+++ b/src/kegscreen.cpp
@@ -217,10 +217,7 @@ bool sendTempReport()
 
     for (int i = 0; i < NUMSENSOR; i++)
     {
-        // TODO - Figure out if we want to do this (send the name as an integer)
-        // doc[KegscreenKeys::sensors][i][KegscreenKeys::name] = device.sensor[i].name;
-        // doc[KegscreenKeys::sensors][i][KegscreenKeys::name] = sensorName[i];
-        doc[KegscreenKeys::sensors][i][KegscreenKeys::name] = i;
+        doc[KegscreenKeys::sensors][i][KegscreenKeys::name] = device.sensor[i].name;
         doc[KegscreenKeys::sensors][i][KegscreenKeys::value] = device.sensor[i].average;  // Always send in C
         doc[KegscreenKeys::sensors][i][KegscreenKeys::enabled] = config.temps.enabled[i];
     }
@@ -276,7 +273,7 @@ bool sendReport(ReportKey thisKey, const char * json) {
                 }
                 else
                 {
-                    Log.verbose(F("%s POST to %s dispatched." CR), reportname[thisKey], connection.c_str());
+                    Log.verbose(F("%s: POST to %s dispatched." CR), reportname[thisKey], connection.c_str());
                 }
             }
             else

--- a/src/kegscreen.cpp
+++ b/src/kegscreen.cpp
@@ -55,69 +55,57 @@ bool reported[5];
 static void (*pf[])(void *optParm, asyncHTTPrequest *report, int readyState) = {
     reportCBTapInfo, reportCBPourReport, reportCBKickReport, reportCBCoolState, reportCBTempReport};
 
+#define kegscreenIsEnabled (config.kegscreen.url != NULL && config.kegscreen.url[0] != '\0')
+
+
+void CommonReportFields(JsonDocument &doc, ReportKey reportkey) {
+    char guid[17];
+    getGuid(guid);
+    doc[KegscreenKeys::api] = API_KEY;
+    doc[KegscreenKeys::guid] = guid;
+    doc[KegscreenKeys::hostname] = config.copconfig.hostname;
+    doc[KegscreenKeys::breweryname] = config.copconfig.breweryname;
+    doc[KegscreenKeys::kegeratorname] = config.copconfig.kegeratorname;
+    doc[KegscreenKeys::reporttype] = reporttype[reportkey];
+}
+
 bool sendTapInfoReport(int tapid)
 { // Push complete tap info (single tap) when tap is flipped to active or the data is changed
     bool retval = true;
     ReportKey reportkey = KS_TAPINFO;
     if (tapid >= 0 && tapid <= NUMTAPS)
     {
-        if (config.kegscreen.url != NULL && config.kegscreen.url[0] != '\0') // If KegScreen is enabled
+        if (kegscreenIsEnabled) // If KegScreen is enabled
         {
-            TapInfo tap;
-            strlcpy(tap.api, API_KEY, sizeof(tap.api));
-            getGuid(tap.guid);
-            strlcpy(tap.hostname, config.copconfig.hostname, sizeof(tap.hostname));
-            strlcpy(tap.breweryname, config.copconfig.breweryname, sizeof(tap.breweryname));
-            strlcpy(tap.kegeratorname, config.copconfig.kegeratorname, sizeof(tap.kegeratorname));
-            strlcpy(tap.reporttype, reporttype[reportkey], sizeof(tap.reporttype));
-            tap.imperial = config.copconfig.imperial;
-            tap.tapid = tapid;
-            strlcpy(tap.name, flow.taps[tapid].name, sizeof(tap.name));
-            tap.ppu = flow.taps[tapid].ppu;
-            tap.remaining = flow.taps[tapid].remaining;
-            tap.capacity = flow.taps[tapid].capacity;
-            tap.active = flow.taps[tapid].active;
-            tap.calibrating = flow.taps[tapid].calibrating;
 
             StaticJsonDocument<512> doc;
 
-            doc["api"] = (const char *)tap.api;
-            doc["guid"] = (const char *)tap.guid;
-            doc["hostname"] = (const char *)tap.hostname;
-            doc["breweryname"] = (const char *)tap.breweryname;
-            doc["kegeratorname"] = (const char *)tap.kegeratorname;
-            doc["reporttype"] = (const char *)tap.reporttype;
-            doc["imperial"] = (const int)tap.imperial;
-            doc["tapid"] = (const int)tapid;
-            doc["name"] = (const char *)tap.name;
-            doc["ppu"] = (const int)tap.ppu;
-            doc["remaining"] = (const float)tap.remaining;
-            doc["capacity"] = (const float)tap.capacity;
-            doc["active"] = tap.active;
-            doc["calibrating"] = tap.calibrating;
+            CommonReportFields(doc, reportkey);
 
-            String json;
-            serializeJson(doc, json);
+            doc[KegscreenKeys::imperial] = config.copconfig.imperial;
+            doc[KegscreenKeys::tapid] = tapid;
+            doc[KegscreenKeys::name] = flow.taps[tapid].name;
+            doc[KegscreenKeys::ppu] = flow.taps[tapid].ppu;
+            doc[KegscreenKeys::remaining] = flow.taps[tapid].remaining;
+            doc[KegscreenKeys::capacity] = flow.taps[tapid].capacity;
+            doc[KegscreenKeys::active] = flow.taps[tapid].active;
+            doc[KegscreenKeys::calibrating] = flow.taps[tapid].calibrating;
 
-            if (sendReport(reportkey, json.c_str()))
-            {
-                retval = true;
-            }
-            else
-            {
-                retval = false;
-            }
+            // String json;
+            // serializeJson(doc, json);
+
+            return sendReport(reportkey, doc);
         }
         else
         {
             Log.verbose(F("KegScreen reporting not enabled, skipping." CR));
-            retval = false;
+            return false;
         }
     }
     else
     {
         Log.error(F("Error: Invalid tap submitted to %s (%d)." CR), reportname[reportkey], tapid);
-        retval = true;
+        return true;
     }
     return retval;
 }
@@ -128,44 +116,21 @@ bool sendPourReport(int tapid, float dispensed)
     ReportKey reportkey = KS_POURREPORT;
     if (tapid >= 0 && tapid <= NUMTAPS)
     {
-        if (config.kegscreen.url != NULL && config.kegscreen.url[0] != '\0') // If KegScreen is enabled
+        if (kegscreenIsEnabled) // If KegScreen is enabled
         {
-            PourInfo pour;
-            strlcpy(pour.api, API_KEY, sizeof(pour.api));
-            getGuid(pour.guid);
-            strlcpy(pour.hostname, config.copconfig.hostname, sizeof(pour.hostname));
-            strlcpy(pour.breweryname, config.copconfig.breweryname, sizeof(pour.breweryname));
-            strlcpy(pour.kegeratorname, config.copconfig.kegeratorname, sizeof(pour.kegeratorname));
-            strlcpy(pour.reporttype, reporttype[reportkey], sizeof(pour.reporttype));
-            pour.tapid = tapid;
-            pour.imperial = config.copconfig.imperial;
-            pour.dispensed = dispensed;
-            pour.remaining = flow.taps[tapid].remaining;
-
             StaticJsonDocument<512> doc;
 
-            doc["api"] = (const char *)pour.api;
-            doc["guid"] = (const char *)pour.guid;
-            doc["hostname"] = (const char *)pour.hostname;
-            doc["breweryname"] = (const char *)pour.breweryname;
-            doc["kegeratorname"] = (const char *)pour.kegeratorname;
-            doc["reporttype"] = (const char *)pour.reporttype;
-            doc["tapid"] = (const int)tapid;
-            doc["imperial"] = (const bool)pour.imperial;
-            doc["dispensed"] = (const float)pour.dispensed;
-            doc["remaining"] = (const float)pour.remaining;
+            CommonReportFields(doc, reportkey);
 
-            String json;
-            serializeJson(doc, json);
+            doc[KegscreenKeys::tapid] = tapid;
+            doc[KegscreenKeys::imperial] = config.copconfig.imperial;
+            doc[KegscreenKeys::dispensed] = dispensed;
+            doc[KegscreenKeys::remaining] = flow.taps[tapid].remaining;
 
-            if (sendReport(reportkey, json.c_str()))
-            {
-                retval = true;
-            }
-            else
-            {
-                retval = false;
-            }
+            // String json;
+            // serializeJson(doc, json);
+
+            return sendReport(reportkey, doc);
         }
         else
         {
@@ -183,180 +148,98 @@ bool sendPourReport(int tapid, float dispensed)
 
 bool sendKickReport(int tapid)
 { // Send a kick report when keg kicks
-    bool retval = true;
     ReportKey reportkey = KS_KICKREPORT;
     if (tapid >= 0 && tapid <= NUMTAPS)
     {
-        if (config.kegscreen.url != NULL && config.kegscreen.url[0] != '\0') // If KegScreen is enabled
+        if (kegscreenIsEnabled) // If KegScreen is enabled
         {
-            KickReport kick;
-            strlcpy(kick.api, API_KEY, sizeof(kick.api));
-            getGuid(kick.guid);
-            strlcpy(kick.hostname, config.copconfig.hostname, sizeof(kick.hostname));
-            strlcpy(kick.breweryname, config.copconfig.breweryname, sizeof(kick.breweryname));
-            strlcpy(kick.kegeratorname, config.copconfig.kegeratorname, sizeof(kick.kegeratorname));
-            strlcpy(kick.reporttype, reporttype[reportkey], sizeof(kick.reporttype));
-            kick.tapid = tapid;
-
             StaticJsonDocument<384> doc;
 
-            doc["api"] = (const char *)kick.api;
-            doc["guid"] = (const char *)kick.guid;
-            doc["hostname"] = (const char *)kick.hostname;
-            doc["breweryname"] = (const char *)kick.breweryname;
-            doc["kegeratorname"] = (const char *)kick.kegeratorname;
-            doc["reporttype"] = (const char *)kick.reporttype;
-            doc["tapid"] = (const int)tapid;
+            CommonReportFields(doc, reportkey);
+            doc[KegscreenKeys::tapid] = tapid;
 
-            String json;
-            serializeJson(doc, json);
+            // String json;
+            // serializeJson(doc, json);
 
-            if (sendReport(reportkey, json.c_str()))
-            {
-                retval = true;
-            }
-            else
-            {
-                retval = false;
-            }
+            return sendReport(reportkey, doc);
         }
         else
         {
             Log.verbose(F("KegScreen reporting not enabled, skipping." CR));
-            retval = false;
+            return false;
         }
     }
     else
     {
         Log.error(F("Error: Invalid tap submitted to %s (%d)." CR), reportname[reportkey], tapid);
-        retval = true;
+        return true;
     }
-    return retval;
 }
 
 bool sendCoolStateReport()
 { // Send cooling status when a cooling state changes
     bool retval = true;
-    ReportKey reportkey = KS_COOLSTATE;
-    if (config.kegscreen.url != NULL && config.kegscreen.url[0] != '\0') // If KegScreen is enabled
-    {
-        CoolState cool;
-        strlcpy(cool.api, API_KEY, sizeof(cool.api));
-        getGuid(cool.guid);
-        strlcpy(cool.hostname, config.copconfig.hostname, sizeof(cool.hostname));
-        strlcpy(cool.breweryname, config.copconfig.breweryname, sizeof(cool.breweryname));
-        strlcpy(cool.kegeratorname, config.copconfig.kegeratorname, sizeof(cool.kegeratorname));
-        strlcpy(cool.reporttype, reporttype[reportkey], sizeof(cool.reporttype));
-        cool.coolstate = tstat.state;
+    char guid[17];
+    const ReportKey reportkey = KS_COOLSTATE;
+    StaticJsonDocument<384> doc;
 
-        StaticJsonDocument<384> doc;
-
-        doc["api"] = (const char *)cool.api;
-        doc["guid"] = (const char *)cool.guid;
-        doc["hostname"] = (const char *)cool.hostname;
-        doc["breweryname"] = (const char *)cool.breweryname;
-        doc["kegeratorname"] = (const char *)cool.kegeratorname;
-        doc["reporttype"] = (const char *)cool.reporttype;
-        doc["coolstate"] = (const int)cool.coolstate;
-
-        String json;
-        serializeJson(doc, json);
-
-        if (sendReport(reportkey, json.c_str()))
-        {
-            retval = true;
-        }
-        else
-        {
-            retval = false;
-        }
-    }
-    else
-    {
+    if (!kegscreenIsEnabled) {
         Log.verbose(F("KegScreen reporting not enabled, skipping." CR));
-        retval = false;
+        return false;
     }
-    return retval;
+
+    CommonReportFields(doc, reportkey);
+    doc[KegscreenKeys::coolstate] = tstat.state;
+
+    String json;
+    serializeJson(doc, json);
+
+
+    return sendReport(reportkey, json.c_str());
 }
 
 bool sendTempReport()
 { // Send a temp report on timer
-    bool retval = true;
-    ReportKey reportkey = KS_TEMPREPORT;
-    if (config.kegscreen.url != NULL && config.kegscreen.url[0] != '\0') // If KegScreen is enabled
-    {
-        TempReport temps;
-        strlcpy(temps.api, API_KEY, sizeof(temps.api));
-        getGuid(temps.guid);
-        strlcpy(temps.hostname, config.copconfig.hostname, sizeof(temps.hostname));
-        strlcpy(temps.breweryname, config.copconfig.breweryname, sizeof(temps.breweryname));
-        strlcpy(temps.kegeratorname, config.copconfig.kegeratorname, sizeof(temps.kegeratorname));
-        strlcpy(temps.reporttype, reporttype[reportkey], sizeof(temps.reporttype));
-        temps.imperial = config.copconfig.imperial;
-        temps.controlpoint = config.temps.controlpoint;
-        temps.setpoint = config.temps.setpoint;
-        temps.status = tstat.state;
-        temps.controlenabled = config.temps.controlenabled;
-
-        for (int i = 0; i < NUMSENSOR; i++)
-        {
-            strlcpy(temps.sensor[i].name, device.sensor[i].name, sizeof(temps.sensor[i].name));
-
-            if (config.copconfig.imperial)
-            {
-                temps.sensor[i].average = convertCtoF(device.sensor[i].average);
-            }
-            else
-            {
-                temps.sensor[i].average = device.sensor[i].average;
-            }
-
-            temps.sensor[i].enabled = config.temps.enabled[i];
-        }
-
-        StaticJsonDocument<1024> doc;
-
-        doc["api"] = (const char *)temps.api;
-        doc["guid"] = (const char *)temps.guid;
-        doc["hostname"] = (const char *)temps.hostname;
-        doc["breweryname"] = (const char *)temps.breweryname;
-        doc["kegeratorname"] = (const char *)temps.kegeratorname;
-        doc["reporttype"] = (const char *)temps.reporttype;
-        doc["imperial"] = temps.imperial;
-        doc["controlpoint"] = (const int)temps.controlpoint;
-        doc["setting"] = (const float)temps.setpoint;
-        doc["status"] = (const int)temps.status;
-        doc["controlenabled"] = temps.controlenabled;
-
-        for (int i = 0; i < NUMSENSOR; i++)
-        {
-            doc["sensors"][i]["name"] = (const char *)temps.sensor[i].name;
-            doc["sensors"][i]["value"] = (const float)temps.sensor[i].average;
-            doc["sensors"][i]["enabled"] = temps.sensor[i].enabled;
-        }
-
-        String json;
-        serializeJson(doc, json);
-
-        if (sendReport(reportkey, json.c_str()))
-        {
-            retval = true;
-        }
-        else
-        {
-            retval = false;
-        }
-    }
-    else
+    const ReportKey reportkey = KS_TEMPREPORT;
+    if (!kegscreenIsEnabled) // If KegScreen is enabled
     {
         Log.verbose(F("KegScreen reporting not enabled, skipping." CR));
-        retval = false;
+        return false;
     }
-    return retval;
+
+    StaticJsonDocument<1024> doc;
+
+    CommonReportFields(doc, reportkey);
+
+    doc[KegscreenKeys::imperial] = config.copconfig.imperial;
+    doc[KegscreenKeys::controlpoint] = config.temps.controlpoint;
+    doc[KegscreenKeys::setting] = config.temps.setpoint;
+    doc[KegscreenKeys::status] = tstat.state;
+    doc[KegscreenKeys::controlenabled] = config.temps.controlenabled;
+
+    for (int i = 0; i < NUMSENSOR; i++)
+    {
+        // TODO - Figure out if we want to do this (send the name as an integer)
+        // doc[KegscreenKeys::sensors][i][KegscreenKeys::name] = device.sensor[i].name;
+        // doc[KegscreenKeys::sensors][i][KegscreenKeys::name] = sensorName[i];
+        doc[KegscreenKeys::sensors][i][KegscreenKeys::name] = i;
+        doc[KegscreenKeys::sensors][i][KegscreenKeys::value] = device.sensor[i].average;  // Always send in C
+        doc[KegscreenKeys::sensors][i][KegscreenKeys::enabled] = config.temps.enabled[i];
+    }
+    // String json;
+    // serializeJson(doc, json);
+
+    return sendReport(reportkey, doc);
 }
 
-bool sendReport(ReportKey thisKey, const String &json)
-{ // Handle sending all KegScreen reports
+bool sendReport(ReportKey thisKey, JsonDocument &doc) {
+    char json[1024];
+    serializeJson(doc, json);
+    return sendReport(thisKey, json);
+}
+
+
+bool sendReport(ReportKey thisKey, const char * json) {
     if (reports[thisKey].readyState() == 0 || reports[thisKey].readyState() == 4)
     {
         reported[thisKey] = false;
@@ -388,7 +271,7 @@ bool sendReport(ReportKey thisKey, const String &json)
             if (reports[thisKey].open("POST", connection.c_str()))
             {
                 reports[thisKey].setReqHeader("Content-Type", "application/json");
-                if (!reports[thisKey].send(json.c_str()))
+                if (!reports[thisKey].send(json))
                 {
                     Log.warning(F("Warning: Failed to dispatch %s POST to %s." CR), reportname[thisKey], connection.c_str());
                     return false;

--- a/src/kegscreen.cpp
+++ b/src/kegscreen.cpp
@@ -59,10 +59,8 @@ static void (*pf[])(void *optParm, asyncHTTPrequest *report, int readyState) = {
 
 
 void CommonReportFields(JsonDocument &doc, ReportKey reportkey) {
-    char guid[17];
-    getGuid(guid);
-    doc[KegscreenKeys::api] = API_KEY;
-    doc[KegscreenKeys::guid] = guid;
+    doc[KegscreenKeys::api] = apiKey;
+    doc[KegscreenKeys::guid] = config.copconfig.guid;
     doc[KegscreenKeys::hostname] = config.copconfig.hostname;
     doc[KegscreenKeys::breweryname] = config.copconfig.breweryname;
     doc[KegscreenKeys::kegeratorname] = config.copconfig.kegeratorname;

--- a/src/kegscreen.h
+++ b/src/kegscreen.h
@@ -45,89 +45,91 @@ enum ReportKey
     KS_TEMPREPORT
 };
 
-struct TapInfo
-{
-    char api[32];
-    char guid[17];
-    char hostname[32];
-    char breweryname[64];
-    char kegeratorname[64];
-    char reporttype[16];
-    bool imperial;
-    int tapid;
-    int ppu;
-    char name[32];
-    float capacity;
-    float remaining;
-    bool active;
-    bool calibrating;
-};
+// struct TapInfo
+// {
+//     char api[32];
+//     char guid[17];
+//     char hostname[32];
+//     char breweryname[64];
+//     char kegeratorname[64];
+//     char reporttype[16];
+//     bool imperial;
+//     int tapid;
+//     int ppu;
+//     char name[32];
+//     float capacity;
+//     float remaining;
+//     bool active;
+//     bool calibrating;
+// };
 
-struct PourInfo
-{
-    char api[32];
-    char guid[17];
-    char hostname[32];
-    char breweryname[64];
-    char kegeratorname[64];
-    char reporttype[16];
-    int tapid;
-    bool imperial;
-    float dispensed;
-    float remaining;
-};
+// struct PourInfo
+// {
+//     char api[32];
+//     char guid[17];
+//     char hostname[32];
+//     char breweryname[64];
+//     char kegeratorname[64];
+//     char reporttype[16];
+//     int tapid;
+//     bool imperial;
+//     float dispensed;
+//     float remaining;
+// };
 
-struct KickReport
-{
-    char api[32];
-    char guid[17];
-    char hostname[32];
-    char breweryname[64];
-    char kegeratorname[64];
-    char reporttype[16];
-    int tapid;
-};
+// struct KickReport
+// {
+//     char api[32];
+//     char guid[17];
+//     char hostname[32];
+//     char breweryname[64];
+//     char kegeratorname[64];
+//     char reporttype[16];
+//     int tapid;
+// };
 
-struct CoolState
-{
-    char api[32];
-    char guid[17];
-    char hostname[32];
-    char breweryname[64];
-    char kegeratorname[64];
-    char reporttype[16];
-    int coolstate;
-};
+// struct CoolState
+// {
+//     char api[32];
+//     char guid[17];
+//     char hostname[32];
+//     char breweryname[64];
+//     char kegeratorname[64];
+//     char reporttype[16];
+//     int coolstate;
+// };
 
-struct TempSensor
-{
-    char name[32];
-    double average;
-    bool enabled;
-};
+// struct TempSensor
+// {
+//     char name[32];
+//     double average;
+//     bool enabled;
+// };
 
-struct TempReport
-{
-    char api[32];
-    char guid[17];
-    char hostname[32];
-    char breweryname[64];
-    char kegeratorname[64];
-    char reporttype[16];
-    bool imperial;
-    int controlpoint;
-    float setpoint;
-    int status;
-    bool controlenabled;
-    TempSensor sensor[NUMSENSOR];
-};
+// struct TempReport
+// {
+//     char api[32];
+//     char guid[17];
+//     char hostname[32];
+//     char breweryname[64];
+//     char kegeratorname[64];
+//     char reporttype[16];
+//     bool imperial;
+//     int controlpoint;
+//     float setpoint;
+//     int status;
+//     bool controlenabled;
+//     TempSensor sensor[NUMSENSOR];
+// };
 
 bool sendTapInfoReport(int);                // Push complete tap info (single tap)
 bool sendPourReport(int, float);            // Send pour report when a pour is done (single tap)
 bool sendKickReport(int);                   // Send a kick report when keg kicks
 bool sendCoolStateReport();                 // Send temp status when a cooling state changes
 bool sendTempReport();                      // Send a temp report on timer
-bool sendReport(ReportKey, const String &); // Handle the business of sending report
+// bool sendReport(ReportKey, const String &); // Handle the business of sending report
+bool sendReport(ReportKey thisKey, JsonDocument &doc);
+bool sendReport(ReportKey thisKey, const char * json);
 
 // Callbacks for Async
 void reportCBTapInfo(void *, asyncHTTPrequest *, int);
@@ -141,5 +143,42 @@ extern struct Config config;
 extern struct Flowmeter flow;
 extern struct Devices device;
 extern struct Thermostat tstat;
+
+
+/**
+ * \brief Strings used for JSON keys
+ * \see ControlConstants
+ */
+namespace KegscreenKeys {
+constexpr auto api = "api";
+constexpr auto guid = "guid";
+constexpr auto hostname = "hostname";
+constexpr auto breweryname = "breweryname";
+constexpr auto kegeratorname = "kegeratorname";
+constexpr auto reporttype = "reporttype";
+constexpr auto imperial = "imperial";
+constexpr auto tapid = "tapid";
+constexpr auto name = "name";
+constexpr auto ppu = "ppu";
+constexpr auto remaining = "remaining";
+constexpr auto capacity = "capacity";
+constexpr auto active = "active";
+constexpr auto calibrating = "calibrating";
+constexpr auto dispensed = "dispensed";
+constexpr auto coolstate = "coolstate";
+constexpr auto controlpoint = "controlpoint";
+
+constexpr auto setting = "setting";
+constexpr auto status = "status";
+constexpr auto controlenabled = "controlenabled";
+
+
+
+constexpr auto sensors = "sensors";
+constexpr auto value = "value";
+constexpr auto enabled = "enabled";
+
+};
+
 
 #endif // _KEGSCREEN_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,7 @@ void setup()
         nullDoc("d");
     else
     {
-        Log.notice(F("Started %s version %s/%s (%s) [%s]." CR), API_KEY, fw_version(), fs_version(), branch(), build());
+        Log.notice(F("Started %s version %s/%s (%s) [%s]." CR), apiKey, fw_version(), fs_version(), branch(), build());
     }
 }
 

--- a/src/serialhandler.cpp
+++ b/src/serialhandler.cpp
@@ -35,7 +35,7 @@ void serial()
 #if DOTELNET == true
     char buffer[32];
     strcpy(buffer, (const char *)"Connected to ");
-    strcat(buffer, (const char *)API_KEY);
+    strcat(buffer, (const char *)apiKey);
     strcat(buffer, (const char *)"\n");
     SERIAL.setWelcomeMsg(buffer);
 #endif

--- a/src/tempsensors.h
+++ b/src/tempsensors.h
@@ -59,6 +59,8 @@ void sensorInit();
 void pollTemps();
 double getTempC(uint8_t);
 
+extern const char *sensorName[NUMSENSOR];
+
 extern struct Config config;
 
 #endif // _TEMPSENSORS_H

--- a/src/urltarget.cpp
+++ b/src/urltarget.cpp
@@ -32,8 +32,8 @@ bool sendTargetReport()
     if (config.urltarget.url != NULL && config.urltarget.url[0] != '\0') // If URL Target
     {
         UrlReport urlreport;
-        strlcpy(urlreport.api, API_KEY, sizeof(urlreport.api));
-        getGuid(urlreport.guid);
+        strlcpy(urlreport.api, apiKey, sizeof(urlreport.api));
+        strlcpy(urlreport.guid, config.copconfig.guid, sizeof(urlreport.guid));
         strlcpy(urlreport.hostname, config.copconfig.hostname, sizeof(urlreport.hostname));
         strlcpy(urlreport.breweryname, config.copconfig.breweryname, sizeof(urlreport.breweryname));
         strlcpy(urlreport.kegeratorname, config.copconfig.kegeratorname, sizeof(urlreport.kegeratorname));


### PR DESCRIPTION
Large refactor done by @thorrak  to reduce the amunt of string copies going on in KegScreen processing.

Sizes from debug compiles:

```
devel (initial):
RAM:   [==        ]  16.8% (used 55032 bytes from 327680 bytes)
Flash: [==========]  98.6% (used 1679229 bytes from 1703936 bytes)

devel_shrink (thorrak refactor):
RAM:   [==        ]  16.8% (used 55032 bytes from 327680 bytes)
Flash: [==========]  98.1% (used 1670821 bytes from 1703936 bytes)
-8,408 bytes

Use config.copconfig.guid (reduce execution of the GUID function):
RAM:   [==        ]  16.8% (used 55032 bytes from 327680 bytes)
Flash: [==========]  98.1% (used 1670781 bytes from 1703936 bytes)
-40 bytes

Use API_KEY (idiomatic change):
RAM:   [==        ]  16.8% (used 55032 bytes from 327680 bytes)
Flash: [==========]  98.1% (used 1670789 bytes from 1703936 bytes)
+8 bytes
```