### PR TITLE
Cleanup links when using dataHost

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,7 @@
 - [ ] Fix SPIFFS Editor
 - [ ] Clicking bubblegum machine does not return to index
 - [ ] Temperature data will not reload after failure on Temps
+- [ ] Move `/ota1` to Settings page?
 - [ ] Check `/settings.htm#sensorcontrol`
     - [ ] dataHost On
         - [ ] Dev Web Server

--- a/data/controllerreset.js
+++ b/data/controllerreset.js
@@ -13,7 +13,7 @@ function finishLoad() {
 
 function doResetSignal() {
     if (!dataHostCheckDone) {
-        setTimeout(populateFlow, 10);
+        setTimeout(doResetSignal, 10);
         return;
     }
     var url = dataHost;

--- a/data/ota1.js
+++ b/data/ota1.js
@@ -7,7 +7,7 @@ var loaded = 0;
 function finishLoad() { // Get page data
     loadThisVersion(); // Populate form with controller settings
     loadThatVersion(); // Populate form with controller settings
-    populateTempLink();
+    chooseTempMenu();
     pollComplete();
 }
 
@@ -45,10 +45,6 @@ function loadThisVersion() { // Get current parameters
 function loadThatVersion() { // Get current parameters
     if (!dataHostCheckDone) {
         setTimeout(loadThatVersion, 10);
-        return;
-    }
-    if (!dataHostCheckDone) {
-        setTimeout(populateFlow, 10);
         return;
     }
     var url = dataHost;

--- a/data/settings.htm
+++ b/data/settings.htm
@@ -124,7 +124,7 @@
                         <div class="dropdown-menu">
                             <a class="dropdown-item" data-toggle="tab" href="#flowcal">Calibrate Flowmeters</a>
                             <a class="dropdown-item" data-toggle="tab" href="#reset">Reset Controller</a>
-                            <a class="dropdown-item" href="ota1">Update Application</a>
+                            <a class="dropdown-item" href="/ota1/">Update Application</a>
                             <a class="dropdown-item" data-toggle="tab" href="#wifi">Reset WiFi</a>
                         </div>
                     </li>
@@ -2135,7 +2135,7 @@
                             </p>
                             <div class="row col-sm-12 justify-content-center">
                                 <p class="card-text">
-                                    <a href="controllerreset" class="btn btn-warning">Reset Controller</a>
+                                    <a href="/controllerreset/" class="btn btn-warning">Reset Controller</a>
                                 </p>
                             </div>
                         </div>
@@ -2157,7 +2157,7 @@
                             </p>
                             <div class="row col-sm-12 justify-content-center">
                                 <p class="card-text">
-                                    <a href="wifireset" class="btn btn-danger">Reset WiFi</a>
+                                    <a href="/wifireset/" class="btn btn-danger">Reset WiFi</a>
                                 </p>
                             </div>
                         </div>

--- a/data/settings.js
+++ b/data/settings.js
@@ -544,7 +544,7 @@ function processSensorControlPost(url, obj) {
         kegcal: kegcal,
         enablekeg: enablekeg
     }
-    putData(url, data, true, true);
+    putData(url, data);
 }
 
 function processKegScreenPost(url, obj) {
@@ -944,6 +944,6 @@ function processTapCalPost(url, obj) {
         tapnum: tapnum,
         ppu: ppu
     }
-    putData(url, data, false, true);
+    putData(url, data, false, true); // TODO:  See if we can do this without "newdata"
     resetFlowCalForm();
 }

--- a/data/wifireset.js
+++ b/data/wifireset.js
@@ -1,17 +1,20 @@
 // Support WiFi Reset
 
+var loaded = 0;
+var numReq = 1;
+
 toggleLoader("off");
 
 function finishLoad() {
     if (!dataHostCheckDone) {
-        setTimeout(populateFlow, 10);
+        setTimeout(finishLoad, 10);
         return;
     }
     var url = dataHost;
     while (url.endsWith("/")) {
         url = url.slice(0, -1)
     }
-    // populateTempLink(); // We don't need this but it's here so I rememnber not to add it again
+    // chooseTempMenu(); // We don't need this but it's here so I rememnber not to add it again
     // This actually resets wifi settings, after
     // this it's all over.  No need to try anything
     // else


### PR DESCRIPTION
Some minor cleanup when checking for dataHost usage.  Found a few more areas to normalize `/path/` formatted usage.