### PR TITLE
Use reset when setting cal

### DIFF
--- a/src/webpagehandler.cpp
+++ b/src/webpagehandler.cpp
@@ -1148,6 +1148,7 @@ HANDLER_STATE handleSensorPost(AsyncWebServerRequest *request) // Handle sensor 
     if (didChange)
     {
         setDoSaveConfig();
+        sensorReInit();
     }
     if (didFail)
     {


### PR DESCRIPTION
Call `sensorReInit()` when sensor configuration is saved.