### PR TITLE
Fix KegScreen/KSTV mDNS Responses

### DIFF
--- a/src/kegscreen.cpp
+++ b/src/kegscreen.cpp
@@ -299,7 +299,6 @@ bool sendReport(ReportKey thisKey, const char * json) {
 
 void doKSMDNS()
 {
-    MDNS.addService(AppKeys::kegscreen, AppKeys::tcp, PORT);
     MDNS.addService(KegScreenKeys::kstv, AppKeys::tcp, PORT);
 
 // TXT records

--- a/src/kegscreen.cpp
+++ b/src/kegscreen.cpp
@@ -303,7 +303,7 @@ void doKSMDNS()
 
 // TXT records
     MDNS.addServiceTxt(KegScreenKeys::kstv, AppKeys::tcp, KegScreenKeys::devicetype, AppKeys::apikey);
-    MDNS.addServiceTxt(KegScreenKeys::kstv, AppKeys::tcp, F("path"), KegScreenKeys::kstv_path);
+    MDNS.addServiceTxt(KegScreenKeys::kstv, AppKeys::tcp, KegScreenKeys::path, KegScreenKeys::kstv_path);
     MDNS.addServiceTxt(KegScreenKeys::kstv, AppKeys::tcp, KegScreenKeys::appendID, "no");
     MDNS.addServiceTxt(KegScreenKeys::kstv, AppKeys::tcp, KegScreenKeys::deviceid, app.copconfig.guid);
 }

--- a/src/kegscreen.h
+++ b/src/kegscreen.h
@@ -78,7 +78,8 @@ namespace KegScreenKeys {
     // JSON/MDNS Keys
     constexpr auto name ="name";
     constexpr auto devicetype ="deviceType";
-    constexpr auto appendID = "appenddID";
+    constexpr auto path="path";
+    constexpr auto appendID = "appendID";
     constexpr auto deviceid = "deviceID";
 };
 


### PR DESCRIPTION
This PR does three things:
- Removes the kegscreen service announcement
- Fixes the typo in the "appendID" key
- Minor cleanup

The kegscreen service announcement is the big one, as the mispelled key will just be ignored (and the default value is "no").